### PR TITLE
feat: add simple coinflip website

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,40 @@
+# Node / package managers
+node_modules/
+.npm/
+.pnpm-store/
+yarn.lock
+package-lock.json
+pnpm-lock.yaml
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+pnpm-debug.log*
+*.log
+
+# Env
+.env
+.env.*
+*.local
+
+# Editors / OS
+.vscode/
+.idea/
+.DS_Store
+Thumbs.db
+
+# Build outputs / caches
+dist/
+build/
+out/
+coverage/
+.nyc_output/
+.cache/
+.parcel-cache/
+.tmp/
+
+# Misc
+*.swp
+*.swo
+*.tmp

--- a/README.md
+++ b/README.md
@@ -1,3 +1,43 @@
-# Test Repository for Mini-SWE Agent
+# Coinflip
 
-This is a test repository for the PRD to PR workflow.
+A simple, static single-page Coinflip website. It shows an animated coin, lets you flip with a button or keyboard (Space/Enter), displays the result, keeps running counts for Heads/Tails/Total, shows the last 10 flips, and persists everything in your browser (localStorage). No build step required.
+
+## Features
+
+- Accessible, keyboard-friendly UI
+- Flip via button or Space/Enter
+- CSS 3D coin flip animation (800ms)
+- Prevents multiple flips during animation
+- Crypto-strong randomness via `crypto.getRandomValues` with Math.random fallback (50/50)
+- Counters for Heads, Tails, and Total
+- Last 10 flips history
+- Persistent state using `localStorage`
+- Reset button clears counts and history
+- Responsive, centered layout with visible focus states
+- Ready to deploy from repository root (GitHub Pages)
+
+## How to run locally
+
+- Option 1: Just open `index.html` in your browser.
+- Option 2 (local server):
+  - Using npm: `npx serve`
+  - Using Python: `python3 -m http.server 8080` (then open http://localhost:8080)
+
+Keyboard shortcut: Press Space or Enter to flip the coin.
+
+## Deploy to GitHub Pages
+
+1. Push the site files (index.html, style.css, script.js) to your repository’s default branch.
+2. In your repository, go to Settings → Pages.
+3. Under “Build and deployment”, set Source to “Deploy from a branch”.
+4. Select your default branch and set the folder to “/ (root)”.
+5. Save. After a few minutes, your site will be live at the provided Pages URL.
+
+## Files
+
+- `index.html` — Single-page app UI and structure
+- `style.css` — Responsive styles, focus states, and flip animation
+- `script.js` — Random flip logic, UI updates, storage, and keyboard support
+- `.gitignore` — Common ignores for web projects
+
+No build step or extra tooling is required.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,68 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Coinflip</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <a class="skip-link" href="#main">Skip to content</a>
+  <header class="site-header" role="banner">
+    <h1>Coinflip</h1>
+  </header>
+
+  <main id="main" class="container" role="main">
+    <section class="coin-area" aria-labelledby="coin-section-title">
+      <h2 id="coin-section-title" class="visually-hidden">Coin</h2>
+
+      <div class="coin-wrapper">
+        <div id="coin" class="coin" role="img" aria-live="polite" aria-label="Coin showing Heads" data-face="heads">
+          <div class="face front" aria-hidden="true">Heads</div>
+          <div class="face back" aria-hidden="true">Tails</div>
+        </div>
+      </div>
+
+      <div class="controls">
+        <button id="flipBtn" type="button" class="btn primary" aria-label="Flip the coin (Space or Enter)" aria-controls="coin result historyList">
+          Flip
+        </button>
+        <button id="resetBtn" type="button" class="btn" aria-label="Reset counters and history">
+          Reset
+        </button>
+      </div>
+
+      <p id="result" class="result" role="status" aria-live="polite" aria-atomic="true">Press Flip to start</p>
+
+      <section class="stats" aria-labelledby="stats-title">
+        <h2 id="stats-title" class="visually-hidden">Statistics</h2>
+        <div class="stat">
+          <span class="label">Heads</span>
+          <span id="headsCount" class="value">0</span>
+        </div>
+        <div class="stat">
+          <span class="label">Tails</span>
+          <span id="tailsCount" class="value">0</span>
+        </div>
+        <div class="stat">
+          <span class="label">Total</span>
+          <span id="totalCount" class="value">0</span>
+        </div>
+      </section>
+
+      <section class="history" aria-labelledby="history-title">
+        <h2 id="history-title">Last 10 flips</h2>
+        <ul id="historyList" class="history-list" aria-live="polite" aria-atomic="false"></ul>
+      </section>
+    </section>
+  </main>
+
+  <footer class="site-footer">
+    <p>
+      Tip: Press Space or Enter to flip the coin. The app stores your counts and history locally in your browser.
+    </p>
+  </footer>
+
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,193 @@
+(function () {
+  'use strict';
+
+  const FLIP_DURATION_MS = 800; // must match CSS --flip-duration
+  const STORAGE_KEY = 'coinflip.v1';
+
+  // DOM elements
+  const coinEl = document.getElementById('coin');
+  const flipBtn = document.getElementById('flipBtn');
+  const resetBtn = document.getElementById('resetBtn');
+  const resultEl = document.getElementById('result');
+  const headsCountEl = document.getElementById('headsCount');
+  const tailsCountEl = document.getElementById('tailsCount');
+  const totalCountEl = document.getElementById('totalCount');
+  const historyListEl = document.getElementById('historyList');
+
+  // App state
+  let state = {
+    heads: 0,
+    tails: 0,
+    total: 0,
+    history: [] // newest at end; display last 10 most recent first
+  };
+
+  let isFlipping = false;
+
+  function loadState() {
+    try {
+      const raw = localStorage.getItem(STORAGE_KEY);
+      if (!raw) return;
+      const data = JSON.parse(raw);
+      if (typeof data !== 'object' || !data) return;
+      state.heads = Number.isFinite(data.heads) ? data.heads : 0;
+      state.tails = Number.isFinite(data.tails) ? data.tails : 0;
+      state.total = Number.isFinite(data.total) ? data.total : (state.heads + state.tails);
+      state.history = Array.isArray(data.history) ? data.history.slice(-200).filter(v => v === 'H' || v === 'T') : [];
+    } catch {
+      // ignore malformed storage
+    }
+  }
+
+  function saveState() {
+    try {
+      localStorage.setItem(STORAGE_KEY, JSON.stringify(state));
+    } catch {
+      // storage might be unavailable (private mode), fail silently
+    }
+  }
+
+  function updateStatsUI() {
+    headsCountEl.textContent = String(state.heads);
+    tailsCountEl.textContent = String(state.tails);
+    totalCountEl.textContent = String(state.total);
+  }
+
+  function updateHistoryUI() {
+    historyListEl.innerHTML = '';
+    const last10 = state.history.slice(-10).reverse(); // newest first
+    for (const item of last10) {
+      const li = document.createElement('li');
+      const isHeads = item === 'H';
+      li.className = isHeads ? 'heads' : 'tails';
+      li.textContent = isHeads ? 'Heads' : 'Tails';
+      li.setAttribute('aria-label', isHeads ? 'Heads' : 'Tails');
+      historyListEl.appendChild(li);
+    }
+  }
+
+  function setCoinFace(face) {
+    coinEl.setAttribute('data-face', face); // "heads" | "tails"
+    coinEl.setAttribute('aria-label', `Coin showing ${face === 'heads' ? 'Heads' : 'Tails'}`);
+  }
+
+  function fairFlip() {
+    try {
+      const u32 = new Uint32Array(1);
+      crypto.getRandomValues(u32);
+      // Use least significant bit for a uniform 50/50 outcome
+      return (u32[0] & 1) === 1; // true => Heads
+    } catch {
+      // Fallback
+      return Math.random() >= 0.5;
+    }
+  }
+
+  function beginFlipAnimation(targetFace) {
+    // Compute start and delta rotations so final orientation matches targetFace
+    const currentFace = coinEl.getAttribute('data-face') === 'tails' ? 'tails' : 'heads';
+    const startDeg = currentFace === 'tails' ? 180 : 0;
+    const endDeg = targetFace === 'tails' ? 180 : 0;
+    let delta = endDeg - startDeg; // -180, 0, or 180
+
+    // Configure CSS variables for animation
+    coinEl.style.setProperty('--start-rot', `${startDeg}deg`);
+    coinEl.style.setProperty('--delta-rot', `${delta}deg`);
+    coinEl.style.setProperty('--spins', '3');
+
+    // Trigger animation
+    coinEl.classList.add('flipping');
+  }
+
+  function endFlipAnimation() {
+    coinEl.classList.remove('flipping');
+    // Clean up CSS vars (optional)
+    coinEl.style.removeProperty('--start-rot');
+    coinEl.style.removeProperty('--delta-rot');
+    coinEl.style.removeProperty('--spins');
+  }
+
+  function flip() {
+    if (isFlipping) return;
+
+    isFlipping = true;
+    flipBtn.disabled = true;
+    flipBtn.setAttribute('aria-disabled', 'true');
+    resultEl.textContent = 'Flipping...';
+    resultEl.setAttribute('aria-busy', 'true');
+
+    const heads = fairFlip(); // true => Heads, false => Tails
+    const targetFace = heads ? 'heads' : 'tails';
+
+    // Animate
+    beginFlipAnimation(targetFace);
+
+    // Complete after duration
+    window.setTimeout(() => {
+      // Update the static face and UI
+      setCoinFace(targetFace);
+      if (heads) {
+        state.heads += 1;
+      } else {
+        state.tails += 1;
+      }
+      state.total += 1;
+      state.history.push(heads ? 'H' : 'T');
+      // Keep history reasonable
+      if (state.history.length > 500) {
+        state.history = state.history.slice(-300);
+      }
+
+      updateStatsUI();
+      updateHistoryUI();
+      resultEl.textContent = heads ? 'Heads' : 'Tails';
+      resultEl.removeAttribute('aria-busy');
+
+      saveState();
+      endFlipAnimation();
+
+      flipBtn.disabled = false;
+      flipBtn.setAttribute('aria-disabled', 'false');
+      isFlipping = false;
+    }, FLIP_DURATION_MS);
+  }
+
+  function resetAll() {
+    if (isFlipping) return;
+    state = { heads: 0, tails: 0, total: 0, history: [] };
+    setCoinFace('heads');
+    resultEl.textContent = 'Press Flip to start';
+    updateStatsUI();
+    updateHistoryUI();
+    try { localStorage.removeItem(STORAGE_KEY); } catch {}
+  }
+
+  // Keyboard shortcuts: Space / Enter trigger flip
+  function onKeydown(e) {
+    const key = e.key || e.code;
+    if (key === ' ' || key === 'Spacebar' || key === 'Space' || key === 'Enter') {
+      e.preventDefault();
+      flip();
+    }
+  }
+
+  // Initialize
+  function init() {
+    loadState();
+
+    // Set initial UI
+    setCoinFace((state.heads || state.tails) ? (state.history[state.history.length - 1] === 'T' ? 'tails' : 'heads') : 'heads');
+    updateStatsUI();
+    updateHistoryUI();
+
+    flipBtn.addEventListener('click', flip);
+    resetBtn.addEventListener('click', resetAll);
+    document.addEventListener('keydown', onKeydown, { passive: false });
+  }
+
+  if (document.readyState === 'loading') {
+    document.addEventListener('DOMContentLoaded', init, { once: true });
+  } else {
+    init();
+  }
+})();

--- a/style.css
+++ b/style.css
@@ -1,0 +1,271 @@
+:root {
+  --bg: #0f172a;            /* slate-900 */
+  --panel: #111827;         /* gray-900 */
+  --text: #e5e7eb;          /* gray-200 */
+  --muted: #9ca3af;         /* gray-400 */
+  --accent: #22d3ee;        /* cyan-400 */
+  --accent-strong: #06b6d4; /* cyan-500 */
+  --good: #34d399;          /* emerald-400 */
+  --warn: #fbbf24;          /* amber-400 */
+  --danger: #f87171;        /* red-400 */
+
+  --radius: 16px;
+  --shadow: 0 10px 30px rgba(0, 0, 0, 0.35);
+
+  /* Flip animation custom properties */
+  --start-rot: 0deg;
+  --delta-rot: 0deg;
+  --spins: 3;
+  --flip-duration: 800ms;
+}
+
+*,
+*::before,
+*::after {
+  box-sizing: border-box;
+}
+
+html, body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+  font-family: ui-sans-serif, system-ui, -apple-system, Segoe UI, Roboto, Ubuntu, Cantarell, Noto Sans, "Helvetica Neue", Arial, "Apple Color Emoji", "Segoe UI Emoji";
+  color: var(--text);
+  background: radial-gradient(1200px 800px at 50% -20%, #1f2937 0%, var(--bg) 50%, #0b1222 100%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+}
+
+.site-header, .site-footer {
+  width: 100%;
+  max-width: 960px;
+  padding: 16px;
+}
+
+.site-header h1 {
+  text-align: center;
+  margin: 24px 0 8px;
+  letter-spacing: 0.5px;
+}
+
+.container {
+  width: 100%;
+  max-width: 960px;
+  padding: 16px;
+  display: grid;
+  place-items: center;
+}
+
+.coin-area {
+  width: min(720px, 92vw);
+  background: linear-gradient(180deg, rgba(255,255,255,0.03), rgba(255,255,255,0.01));
+  border: 1px solid rgba(255,255,255,0.08);
+  border-radius: var(--radius);
+  box-shadow: var(--shadow);
+  padding: clamp(16px, 3vw, 32px);
+}
+
+.coin-wrapper {
+  display: grid;
+  place-items: center;
+  margin: 16px 0 8px;
+  perspective: 1000px;
+}
+
+.coin {
+  width: clamp(140px, 30vw, 220px);
+  height: clamp(140px, 30vw, 220px);
+  border-radius: 50%;
+  position: relative;
+  transform-style: preserve-3d;
+  background: radial-gradient(circle at 40% 35%, #374151, #111827 70%);
+  box-shadow:
+    inset 0 6px 14px rgba(0,0,0,0.4),
+    inset 0 -6px 14px rgba(255,255,255,0.06),
+    0 16px 40px rgba(0,0,0,0.45);
+  transition: transform 260ms ease;
+  will-change: transform;
+}
+
+/* Static orientation by face */
+.coin[data-face="heads"] { transform: rotateY(0deg); }
+.coin[data-face="tails"] { transform: rotateY(180deg); }
+
+/* Faces */
+.face {
+  position: absolute;
+  inset: 0;
+  display: grid;
+  place-items: center;
+  font-weight: 700;
+  font-size: clamp(22px, 4.5vw, 36px);
+  color: #fff;
+  border-radius: 50%;
+  backface-visibility: hidden;
+  user-select: none;
+  letter-spacing: 1px;
+}
+.face.front {
+  text-shadow: 0 1px 0 rgba(0,0,0,0.3), 0 0 20px rgba(34,211,238,0.6);
+}
+.face.back {
+  transform: rotateY(180deg);
+  text-shadow: 0 1px 0 rgba(0,0,0,0.3), 0 0 20px rgba(248,113,113,0.6);
+}
+
+/* Flip animation */
+@keyframes coin-flip {
+  0%   { transform: rotateY(var(--start-rot)); }
+  100% { transform: rotateY(calc(var(--start-rot) + var(--delta-rot) + var(--spins) * 360deg)); }
+}
+
+.coin.flipping {
+  animation: coin-flip var(--flip-duration) ease-in-out both;
+  transition: none; /* avoid static transform transitions during animation */
+}
+
+.controls {
+  display: flex;
+  gap: 12px;
+  justify-content: center;
+  margin: 12px 0 8px;
+  flex-wrap: wrap;
+}
+
+.btn {
+  cursor: pointer;
+  border: 1px solid rgba(255,255,255,0.16);
+  background: rgba(255,255,255,0.04);
+  color: var(--text);
+  padding: 10px 16px;
+  border-radius: 10px;
+  font-size: 16px;
+  min-width: 96px;
+  transition: background 160ms ease, transform 80ms ease, border-color 160ms ease;
+}
+.btn:hover {
+  background: rgba(255,255,255,0.08);
+}
+.btn.primary {
+  border-color: rgba(34,211,238,0.35);
+  background: linear-gradient(180deg, rgba(34,211,238,0.15), rgba(34,211,238,0.05));
+}
+.btn.primary:hover {
+  border-color: rgba(34,211,238,0.55);
+  background: linear-gradient(180deg, rgba(34,211,238,0.22), rgba(34,211,238,0.08));
+}
+.btn:active {
+  transform: translateY(1px);
+}
+.btn:disabled,
+.btn[aria-disabled="true"] {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.result {
+  text-align: center;
+  margin: 10px 0 14px;
+  min-height: 1.5em;
+  font-size: 18px;
+}
+
+.stats {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  gap: 10px;
+  margin-top: 8px;
+}
+.stat {
+  display: grid;
+  gap: 6px;
+  justify-items: center;
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid rgba(255,255,255,0.08);
+  background: rgba(255,255,255,0.03);
+}
+.stat .label {
+  color: var(--muted);
+  font-size: 14px;
+}
+.stat .value {
+  font-size: 22px;
+  font-weight: 700;
+}
+
+.history {
+  margin-top: 18px;
+}
+.history h2 {
+  text-align: center;
+  font-size: 18px;
+  margin: 0 0 10px;
+  color: var(--muted);
+}
+.history-list {
+  list-style: none;
+  padding: 0;
+  margin: 0 auto;
+  max-width: 480px;
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(80px, 1fr));
+  gap: 8px;
+}
+.history-list li {
+  text-align: center;
+  padding: 8px 10px;
+  border-radius: 10px;
+  border: 1px solid rgba(255,255,255,0.08);
+  background: rgba(255,255,255,0.03);
+  font-weight: 600;
+}
+.history-list li.heads { color: var(--good); border-color: rgba(52,211,153,0.35); }
+.history-list li.tails { color: var(--danger); border-color: rgba(248,113,113,0.35); }
+
+/* Focus visibility and skip link */
+:where(a, button, [tabindex]):focus-visible {
+  outline: 3px solid var(--accent);
+  outline-offset: 3px;
+  border-radius: 10px;
+}
+.skip-link {
+  position: absolute;
+  left: -9999px;
+  top: auto;
+  width: 1px;
+  height: 1px;
+  overflow: hidden;
+}
+.skip-link:focus {
+  position: static;
+  width: auto;
+  height: auto;
+  padding: 8px 12px;
+  background: #000;
+  color: #fff;
+  border-radius: 8px;
+  margin: 8px;
+}
+
+/* Utilities */
+.visually-hidden {
+  position: absolute !important;
+  height: 1px; width: 1px;
+  overflow: hidden;
+  clip: rect(1px, 1px, 1px, 1px);
+  white-space: nowrap;
+}
+
+/* Reduced motion preference */
+@media (prefers-reduced-motion: reduce) {
+  .coin.flipping {
+    animation-duration: 1ms;
+  }
+  .btn, .coin {
+    transition: none !important;
+  }
+}


### PR DESCRIPTION
This PR adds a simple static Coinflip website.

Overview:
- Single-page app (index.html) titled Coinflip with an animated coin, Flip and Reset buttons, result text, counters (Heads/Tails/Total), and a Last 10 flips section.
- Accessible markup and keyboard support: Space/Enter triggers a flip.
- CSS 3D flip animation runs for 800ms and prevents multiple flips during animation.
- Randomness uses crypto.getRandomValues with a Math.random fallback to maintain a 50/50 distribution.
- Counts and history persist to localStorage; Reset clears state.
- Responsive design, centered layout, visible focus states.
- No build step required; ready to deploy to GitHub Pages from repo root.

Files changed:
- index.html
- style.css
- script.js
- README.md
- .gitignore

How to test locally:
1) Open index.html directly in a browser, or run `npx serve` and open the served URL.
2) Click Flip or press Space/Enter. Observe the 800ms flip animation and result text.
3) Verify counters update, total increments, and history shows last 10 flips.
4) Refresh the page to confirm persistence. Click Reset to clear state.