### PR TITLE
Add formatDate utility and test

### DIFF
--- a/date-utils.js
+++ b/date-utils.js
@@ -1,0 +1,19 @@
+'use strict';
+
+/**
+ * Format a Date object as 'YYYY-MM-DD'.
+ * @param {Date} date
+ * @returns {string}
+ */
+function formatDate(date) {
+  if (!(date instanceof Date) || isNaN(date)) {
+    throw new TypeError('formatDate expects a valid Date instance');
+  }
+  const pad = n => String(n).padStart(2, '0');
+  const y = date.getFullYear();
+  const m = pad(date.getMonth() + 1);
+  const d = pad(date.getDate());
+  return `${y}-${m}-${d}`;
+}
+
+module.exports = { formatDate };

--- a/date-utils.test.js
+++ b/date-utils.test.js
@@ -1,0 +1,30 @@
+'use strict';
+
+const assert = require('assert');
+const { formatDate } = require('./date-utils');
+
+function test(name, fn) {
+  try {
+    fn();
+    console.log('PASS:', name);
+  } catch (e) {
+    console.error('FAIL:', name, '-', e && e.message ? e.message : e);
+    process.exitCode = 1;
+  }
+}
+
+test('pads month and day', () => {
+  const d = new Date(2023, 0, 5); // Jan 5, 2023
+  assert.strictEqual(formatDate(d), '2023-01-05');
+});
+
+test('handles double-digit month/day', () => {
+  const d = new Date(1999, 10, 15); // Nov 15, 1999
+  assert.strictEqual(formatDate(d), '1999-11-15');
+});
+
+test('throws on invalid input', () => {
+  let threw = false;
+  try { formatDate('not-a-date'); } catch (_) { threw = true; }
+  assert.strictEqual(threw, true);
+});


### PR DESCRIPTION
Add date-utils.js with formatDate(date) exporting YYYY-MM-DD and a simple test.