### PR TITLE
docs: fix hyphenation in README (PRD-to-PR)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,3 @@
 # Test Repository for Mini-SWE Agent
 
-This is a test repository for the PRD to PR workflow.
+This is a test repository for the PRD-to-PR workflow.


### PR DESCRIPTION
Fix minor documentation bug: use 'PRD-to-PR' hyphenation.